### PR TITLE
Fix infinite recursion in Preact 10.4.0

### DIFF
--- a/src/is-where.js
+++ b/src/is-where.js
@@ -28,6 +28,10 @@ const ATTRIBUTE_PRESENT = {exists: true};
 const _isWhere = (where, target) => {
   // Check each key from where
   for (const [key, value] of entries(where)) {
+    // do not recurse into private keys
+    if (key[0] === '_') {
+      continue;
+    }
 
     // If the key is set, but value is undefined, we ignore it
     if (typeof value === 'undefined') {


### PR DESCRIPTION
VNodes now have a `._original` (or `.__v`) property pointing to their original representation, which his most often a self-reference. This causes an infinite loop. I believe it should be very safe to simply ignore all `_`-prefixed keys, as these are internal properties used only by the renderer.